### PR TITLE
Update oauth_client.py

### DIFF
--- a/athera/auth/oauth_client.py
+++ b/athera/auth/oauth_client.py
@@ -84,13 +84,13 @@ class OAuthClient(object):
         self.server.join()
 
     def run_flask_server(self):
-        app = flask.Flask("CallbackServer")
-        app.secret_key = os.urandom(24)
-        app.use_reloader = False
-        app.debug = False
-        app.add_url_rule("/" + self.__redirect_endpoint, "callback", self.route_callback)
-        app.add_url_rule("/" + self.__token_granted_endpoint, "complete", self.route_token_granted)
-        app.run()
+        self.app = flask.Flask("CallbackServer")
+        self.app.secret_key = os.urandom(24)
+        self.app.use_reloader = False
+        self.app.debug = False
+        self.app.add_url_rule("/" + self.__redirect_endpoint, "callback", self.route_callback)
+        self.app.add_url_rule("/" + self.__token_granted_endpoint, "complete", self.route_token_granted)
+        self.app.run()
 
     def authorize(self):
         self.logger.info("Authorize called")

--- a/athera/auth/oauth_client.py
+++ b/athera/auth/oauth_client.py
@@ -69,16 +69,10 @@ class OAuthClient(object):
         if self.server:
             return
 
-        self.app = flask.Flask("CallbackServer")
         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = "1"
-        self.app.secret_key = os.urandom(24)
-        self.app.use_reloader = False
-        self.app.debug = False
-        self.app.add_url_rule("/" + self.__redirect_endpoint, "callback", self.route_callback)
-        self.app.add_url_rule("/" + self.__token_granted_endpoint, "complete", self.route_token_granted)
-                
+
         self.queue = multiprocessing.Queue()
-        self.server = multiprocessing.Process(target=self.app.run)
+        self.server = multiprocessing.Process(target=run_flask_server)
         self.server.start()
 
     def stop_callback_server(self):
@@ -88,6 +82,15 @@ class OAuthClient(object):
 
         self.server.terminate()
         self.server.join()
+
+    def run_flask_server(self):
+        app = flask.Flask("CallbackServer")
+        app.secret_key = os.urandom(24)
+        app.use_reloader = False
+        app.debug = False
+        app.add_url_rule("/" + self.__redirect_endpoint, "callback", self.route_callback)
+        app.add_url_rule("/" + self.__token_granted_endpoint, "complete", self.route_token_granted)
+        app.run()
 
     def authorize(self):
         self.logger.info("Authorize called")

--- a/athera/auth/oauth_client.py
+++ b/athera/auth/oauth_client.py
@@ -72,7 +72,7 @@ class OAuthClient(object):
         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = "1"
 
         self.queue = multiprocessing.Queue()
-        self.server = multiprocessing.Process(target=run_flask_server)
+        self.server = multiprocessing.Process(target=self.run_flask_server)
         self.server.start()
 
     def stop_callback_server(self):


### PR DESCRIPTION
https://foundry.tpondemand.com/entity/383076-athera-cant-generate-api-token-on

Windows uses pickle to serialize objects that need to be passed to spawned processes, but Flask objects cannot be pickled (due to the fact that they contain a lock). This change moves the creation and running of the flask server into the spawned process.